### PR TITLE
fix: extrai porta a ser usado pela aplicacao como constante

### DIFF
--- a/src/config/apolloEngine.js
+++ b/src/config/apolloEngine.js
@@ -1,7 +1,14 @@
+import debug from 'debug'
 import { Engine } from 'apollo-engine'
+import { getPort, OPTIMUS_PRIME_DEBUG } from './constants'
+
+const log = debug(OPTIMUS_PRIME_DEBUG)
 
 export const startApolloEngine = (app) => {
-  const { ENGINE_API_KEY, PORT, NODE_ENV } = process.env
+  const { ENGINE_API_KEY, NODE_ENV } = process.env
+  const port = getPort()
+
+  log(`Starting apollo engine on port ${port}`)
 
   if (NODE_ENV === 'production') {
     const engine = new Engine({
@@ -11,11 +18,11 @@ export const startApolloEngine = (app) => {
           level: 'DEBUG'
         }
       },
-      graphqlPort: PORT || 8003,
+      graphqlPort: port,
       endpoint: '/graphql',
       dumpTraffic: true
-    }).start()
-
+    })
+    engine.start()
     app.use(engine.expressMiddleware())
   }
 }

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,0 +1,2 @@
+export const OPTIMUS_PRIME_DEBUG = 'optimus-prime:server'
+export const getPort = () => process.env.PORT || '3000'

--- a/src/server.js
+++ b/src/server.js
@@ -3,13 +3,14 @@
 import http from 'http'
 import debug from 'debug'
 import { initializeApp } from './app'
+import { OPTIMUS_PRIME_DEBUG, getPort } from './config/constants'
 
-const log = debug('optimus-prime:server')
+const log = debug(OPTIMUS_PRIME_DEBUG)
 
 start()
 
 async function start () {
-  const port = normalizePort(process.env.PORT || '3000')
+  const port = normalizePort(getPort())
   const app = await initializeApp(port)
   createServer(app, port)
 }


### PR DESCRIPTION
Pretendo consertar esse erro do heroku

```
2017-10-27T12:03:51.172371+00:00 app[web.1]: > optimus-prime@0.0.0 start /app
2017-10-27T12:03:51.172372+00:00 app[web.1]: > DEBUG=optimus-prime:* node ./dist/server.js
2017-10-27T12:03:51.172373+00:00 app[web.1]: 
2017-10-27T12:03:52.913712+00:00 app[web.1]: this does not look like a git repo
2017-10-27T12:03:53.047295+00:00 app[web.1]: (node:36) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: engine.expressMiddleware is not a function
2017-10-27T12:03:53.082249+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:03:53Z" level=info msg="Starting proxy with restarts..."
2017-10-27T12:03:53.120406+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:03:53Z" level=info msg="Set log level" level=debug
2017-10-27T12:03:53.120671+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:03:53Z" level=info msg="Creating frontend." endpoint=/graphql host=127.0.0.1 port=34165
2017-10-27T12:03:53.120715+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:03:53Z" level=info msg="Creating HTTP server." address="127.0.0.1:34165"
2017-10-27T12:03:53.120761+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:03:53Z" level=info msg="Added new origin" url="http://127.0.0.1:38987/graphql"
2017-10-27T12:03:53.120824+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:03:53Z" level=info msg="Engine proxy started." version=2017.10-425-gdd4873ae
2017-10-27T12:03:53.120871+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:03:53Z" level=info msg="Started HTTP server." address="127.0.0.1:34165"
2017-10-27T12:03:58.123357+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:03:58Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:03.127666+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:03Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:08.121149+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:08Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:13.133879+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:13Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:18.155425+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:18Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:23.123022+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:23Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:25.313415+00:00 heroku[router]: at=error code=H20 desc="App boot timeout" method=GET path="/graphiql" host=optimus-prime-graphql.herokuapp.com request_id=b5b90fbd-8973-402c-83af-1ba038e7de7a fwd="191.32.38.169" dyno= connect= service= status=503 bytes= protocol=https
2017-10-27T12:04:28.133461+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:28Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:33.122336+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:33Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:38.124262+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:38Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:43.120511+00:00 app[web.1]: EngineProxy ==> time="2017-10-27T12:04:43Z" level=debug msg="reporting-client - [DEBUG] POST https://engine-report.apollodata.com/api/ss/stats"
2017-10-27T12:04:44.321577+00:00 heroku[web.1]: Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch
2017-10-27T12:04:44.321715+00:00 heroku[web.1]: Stopping process with SIGKILL
2017-10-27T12:04:44.381124+00:00 app[web.1]: Error waiting for process to terminate: No child processes
2017-10-27T12:04:44.499898+00:00 heroku[web.1]: Process exited with status 22
2017-10-27T12:04:44.517921+00:00 heroku[web.1]: State changed from starting to crashed
```