### PR TITLE
Retorna array vazio caso não encontre resultados

### DIFF
--- a/src/services/election.js
+++ b/src/services/election.js
@@ -1,8 +1,9 @@
-import {byRoleAndYear} from '../clients/mongo/election'
+import { byRoleAndYear } from '../clients/mongo/election'
 
 export const findCandidatesByRoleAndYear = async (role, year) => {
   const election = await byRoleAndYear(role, year)
-  const candidatesByRole = election[0].post[0].candidates
+  const electionData = election[0] ? election[0] : []
+  const candidatesByRole = electionData.post ? electionData.post[0].candidates : []
   return candidatesByRole.map(candidate => candidate.name)
 }
 

--- a/test/unit/services/election.test.js
+++ b/test/unit/services/election.test.js
@@ -21,4 +21,10 @@ describe('Election service', () => {
     const candidates = await findCandidatesByRoleAndYear('PRESIDENTE', 2014)
     expect(candidates).toEqual(expectedCadidates)
   })
+
+  it('should return empty list when did not found results', async () => {
+    ElectionClient.byRoleAndYear = jest.fn((role, year) => Promise.resolve([]))
+    const candidates = await findCandidatesByRoleAndYear('PRESIDENTE', 2012)
+    expect(candidates).toEqual([])
+  })
 })


### PR DESCRIPTION
Atualmente o optimus-prime quebra caso não encontre resultados.

Por exemplo:
```
{
	"role": "PRESIDENTE",
	"year": 2012
}
```

Deve retornar um array vazio ao invés de `Cannot read property 'post' of undefined`